### PR TITLE
Add Confirm Modal

### DIFF
--- a/src/actions/actionTypes.js
+++ b/src/actions/actionTypes.js
@@ -2,5 +2,5 @@
 This file holds all the actions name 
 that will be used by reducers and other action files.
 */ 
-export const BROWNBAG_NEXT_INLINE = "BROWNBAG_NEXT_INLINE";
-
+export const SHOW_CONFIRM_MODAL_SUCCESS = "SHOW_CONFIRM_MODAL_SUCCESS";
+export const HIDE_CONFIRM_MODAL_SUCCESS = "HIDE_CONFIRM_MODAL_SUCCESS";

--- a/src/actions/confirmModalActions.js
+++ b/src/actions/confirmModalActions.js
@@ -1,0 +1,17 @@
+import * as actions from './actionTypes';
+
+export function showModal(message, brownbagID){
+  // Modal is an object that contains isShowing (boolean) and message (string )
+  return {
+    type: actions.SHOW_CONFIRM_MODAL_SUCCESS,
+    message: message,
+    id: brownbagID
+  };
+}
+
+export function hideModal(){
+  return {
+    type: actions.HIDE_CONFIRM_MODAL_SUCCESS
+
+  };
+}

--- a/src/components/common/ConfirmModal.js
+++ b/src/components/common/ConfirmModal.js
@@ -1,0 +1,41 @@
+import React, {PropTypes} from 'react';
+import {connect} from 'react-redux';
+
+class ConfirmModal extends React.Component {
+  constructor(props){
+    super(props);
+
+  }
+
+  render(){
+    return (
+      <div>
+      {this.props.confirmModal.isShowing &&
+        <div>
+          <div className="confirm-modal-content">
+            <span 
+            className="confirm-modal-message">
+              {this.props.confirmModal.message} {this.props.confirmModal.id}? 
+            </span>
+            <button className="btn" onClick={this.props.onConfirm}>OK</button>
+            <button className="btn cancel-btn" onClick={this.props.onCancel}>Cancel</button>
+          </div>
+        </div>
+       }    
+      </div>
+    );
+  }
+}
+
+ConfirmModal.propTypes = {
+  onConfirm: PropTypes.func,
+  onCancel: PropTypes.func,
+  confirmModal: PropTypes.object
+};
+
+function mapStateToProps (state, ownProps) {
+  return {
+    confirmModal: state.confirmModalReducer
+  };
+}
+export default connect(mapStateToProps)(ConfirmModal);

--- a/src/components/home/shuffleView/BrownBagView/PreviousBrownBag.js
+++ b/src/components/home/shuffleView/BrownBagView/PreviousBrownBag.js
@@ -1,14 +1,31 @@
 import React, {PropTypes} from 'react';
 import {connect} from 'react-redux';
 import UUID from 'node-uuid';
+import * as actions from '../../../../actions/confirmModalActions';
+import ConfirmModal from '../../../common/ConfirmModal';
 
 class PreviousBrownBag extends React.Component {
   constructor(props) {
     super(props);
 
+    this.handleClick = this.handleClick.bind(this);
+    this.handleModalCancel = this.handleModalCancel.bind(this);
+    this.handleConfirm = this.handleConfirm.bind(this);
     this.listPreviousCandidates = this.listPreviousCandidates.bind(this);
   }
   
+ 
+  handleClick(user) {
+    this.props.showModal("Remove user ", user.id);
+  }
+
+  handleConfirm() {
+    this.handleModalCancel();
+  }
+
+  handleModalCancel() {
+    this.props.hideModal();
+  }
  
   listPreviousCandidates(candidates) {
     const listPreviousCandidates = candidates.map((candidate) => 
@@ -28,7 +45,8 @@ class PreviousBrownBag extends React.Component {
             type="checkbox" 
             id="list-checkbox-1" 
             className="mdl-checkbox__input" 
-            checked />
+            checked
+            onClick={() => this.handleClick(candidate)} />
           </label>
         </span>
       </li>
@@ -43,22 +61,39 @@ class PreviousBrownBag extends React.Component {
           <h6>Previous Brownbag</h6>
           <span className="mdl-list__item-sub-title">27 jan</span>
         </div>
+        <button onClick={this.handleConfirm}>delete</button>
         <ul className="mdl-list">
           {this.listPreviousCandidates(this.props.previous_candidates_list)}
         </ul>
+        <ConfirmModal onConfirm={this.handleConfirm} onCancel={this.handleModalCancel} />
       </div>
     );
   }
 }
 
 PreviousBrownBag.propTypes = {
-  previous_candidates_list: PropTypes.array
+  previous_candidates_list: PropTypes.array,
+  confirm_modal: PropTypes.object,
+  showModal: PropTypes.func,
+  hideModal: PropTypes.func
 };
 
 function mapStateToProps(state, ownProps) {
   return {
-    previous_candidates_list: state.previousCandidatesReducer
+    previous_candidates_list: state.previousCandidatesReducer,
+    confirm_modal: state.confirmModalReducer
   };
 }
 
-export default connect(mapStateToProps)(PreviousBrownBag);
+function mapDispatchToProps(dispatch, ownProps) {
+  return {
+    showModal: (message, brownbagID) => {
+      dispatch(actions.showModal(message, brownbagID));  
+    },
+    hideModal: () => {
+      dispatch(actions.hideModal());
+    }
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(PreviousBrownBag);

--- a/src/reducers/confirmModalReducer.js
+++ b/src/reducers/confirmModalReducer.js
@@ -1,0 +1,25 @@
+import * as types from '../actions/actionTypes';
+import initialState from './initialState';
+
+export function confirmModalReducer( state=initialState.confirm_modal, action) {
+  switch (action.type) {
+    case types.SHOW_CONFIRM_MODAL_SUCCESS:
+      return Object.assign(
+        {}, state, {
+          message: action.message,
+          isShowing: true,
+          id: action.id
+        });
+
+    case types.HIDE_CONFIRM_MODAL_SUCCESS:
+      return Object.assign(
+        {}, state, {
+          message: '',
+          isShowing: false,
+          id: 0
+        });  
+  
+    default:
+      return state;  
+  }
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,10 +1,17 @@
 import {combineReducers} from 'redux';
-import {brownbagReducer, previousCandidatesReducer, skippedCandidatesReducer} from './brownbagReducer';
-
+import {
+  brownbagReducer, 
+  previousCandidatesReducer, 
+  skippedCandidatesReducer
+} from './brownbagReducer';
+import {
+  confirmModalReducer
+} from './confirmModalReducer';
 const rootReducer = combineReducers({
   brownbagReducer,
   previousCandidatesReducer,
-  skippedCandidatesReducer
+  skippedCandidatesReducer,
+  confirmModalReducer
 });
 
 export default rootReducer;

--- a/src/reducers/initialState.js
+++ b/src/reducers/initialState.js
@@ -149,5 +149,10 @@ export default {
         "bio": ""
       }
     }
-  ]
+  ],
+  confirm_modal: {
+    isShowing: false,
+    id: 0,
+    message: ''
+  }
 };

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -211,4 +211,33 @@
   height: 70px;
 }
 
-.date {}
+.confirm-modal-content {
+    border-style: solid;
+    border-width: thin;
+    border-color: red;
+    border-radius: 6px;
+    height: 30px;
+    padding: 4px 0px 0px 10px;
+    margin: 2px 2px 2px 39px;
+    width: 85%;
+}
+
+.confirm-modal-message {
+    font-family: monospace;
+    font-size: 18px;
+}
+
+.btn {
+    display: inline-block;
+    padding: 5px 18px;
+    cursor: pointer;
+    text-align: center;
+    color: #fff;
+    background-color: #4CAF50;
+    border-radius: 4px;
+    color: white;
+    margin-left: 10px;
+}
+.cancel-btn {
+  background-color: red;
+} 


### PR DESCRIPTION
# What does this PR do?
This PR creates a confirmation UI modal that lets the current user confirm his/her decision before proceeding over.

# What features does this PR implement?
User has to confirm his/her decisions

# How can this PR be tested?
In the browser, navigate to the _**/home**_ endpoint. In the previous component, Untick any candidate of choice. 